### PR TITLE
Add name_contains param to BaseRepository.list and BaseListAction

### DIFF
--- a/meldingen_core/actions/base.py
+++ b/meldingen_core/actions/base.py
@@ -3,6 +3,7 @@ from typing import Any, Generic, TypeVar
 
 from meldingen_core import SortingDirection
 from meldingen_core.exceptions import NotFoundException
+from meldingen_core.filters import ListFilters
 from meldingen_core.repositories import BaseRepository
 
 T = TypeVar("T")
@@ -33,14 +34,14 @@ class BaseListAction(BaseCRUDAction[T]):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
-        name_contains: str | None = None,
+        filters: ListFilters | None = None,
     ) -> Sequence[T]:
         return await self._repository.list(
             limit=limit,
             offset=offset,
             sort_attribute_name=sort_attribute_name,
             sort_direction=sort_direction,
-            name_contains=name_contains,
+            filters=filters,
         )
 
 

--- a/meldingen_core/actions/base.py
+++ b/meldingen_core/actions/base.py
@@ -3,7 +3,7 @@ from typing import Any, Generic, TypeVar
 
 from meldingen_core import SortingDirection
 from meldingen_core.exceptions import NotFoundException
-from meldingen_core.filters import ListFilters
+from meldingen_core.filters import NameListFilters
 from meldingen_core.repositories import BaseRepository
 
 T = TypeVar("T")
@@ -34,7 +34,7 @@ class BaseListAction(BaseCRUDAction[T]):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
-        filters: ListFilters | None = None,
+        filters: NameListFilters | None = None,
     ) -> Sequence[T]:
         return await self._repository.list(
             limit=limit,

--- a/meldingen_core/actions/base.py
+++ b/meldingen_core/actions/base.py
@@ -33,9 +33,14 @@ class BaseListAction(BaseCRUDAction[T]):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
+        name_contains: str | None = None,
     ) -> Sequence[T]:
         return await self._repository.list(
-            limit=limit, offset=offset, sort_attribute_name=sort_attribute_name, sort_direction=sort_direction
+            limit=limit,
+            offset=offset,
+            sort_attribute_name=sort_attribute_name,
+            sort_direction=sort_direction,
+            name_contains=name_contains,
         )
 
 

--- a/meldingen_core/filters.py
+++ b/meldingen_core/filters.py
@@ -5,6 +5,11 @@ from meldingen_core.statemachine import BaseMeldingState
 
 
 @dataclass
+class ListFilters:
+    name_contains: str | None = None
+
+
+@dataclass
 class MeldingListFilters:
     area: str | None = None
     states: Sequence[BaseMeldingState] | None = None

--- a/meldingen_core/filters.py
+++ b/meldingen_core/filters.py
@@ -5,7 +5,7 @@ from meldingen_core.statemachine import BaseMeldingState
 
 
 @dataclass
-class ListFilters:
+class NameListFilters:
     name_contains: str | None = None
 
 

--- a/meldingen_core/repositories.py
+++ b/meldingen_core/repositories.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Generic, TypeVar
 
 from meldingen_core import SortingDirection
-from meldingen_core.filters import MeldingListFilters
+from meldingen_core.filters import ListFilters, MeldingListFilters
 from meldingen_core.models import Answer, Asset, AssetType, Attachment, Classification, Form, Melding, Question, User
 
 T = TypeVar("T")
@@ -21,7 +21,7 @@ class BaseRepository(Generic[T], metaclass=ABCMeta):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
-        name_contains: str | None = None,
+        filters: ListFilters | None = None,
     ) -> Sequence[T]: ...
 
     @abstractmethod

--- a/meldingen_core/repositories.py
+++ b/meldingen_core/repositories.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from typing import Generic, TypeVar
 
 from meldingen_core import SortingDirection
-from meldingen_core.filters import ListFilters, MeldingListFilters
+from meldingen_core.filters import MeldingListFilters, NameListFilters
 from meldingen_core.models import Answer, Asset, AssetType, Attachment, Classification, Form, Melding, Question, User
 
 T = TypeVar("T")
@@ -21,7 +21,7 @@ class BaseRepository(Generic[T], metaclass=ABCMeta):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
-        filters: ListFilters | None = None,
+        filters: NameListFilters | None = None,
     ) -> Sequence[T]: ...
 
     @abstractmethod

--- a/meldingen_core/repositories.py
+++ b/meldingen_core/repositories.py
@@ -21,6 +21,7 @@ class BaseRepository(Generic[T], metaclass=ABCMeta):
         offset: int | None = None,
         sort_attribute_name: str | None = None,
         sort_direction: SortingDirection | None = None,
+        name_contains: str | None = None,
     ) -> Sequence[T]: ...
 
     @abstractmethod

--- a/tests/test_actions/test_base_actions.py
+++ b/tests/test_actions/test_base_actions.py
@@ -61,7 +61,7 @@ async def test_base_list_action_limit(
 
     await base_list_action(limit=limit)
 
-    spy.assert_called_once_with(limit=limit, offset=None, sort_attribute_name=None, sort_direction=None)
+    spy.assert_called_once_with(limit=limit, offset=None, sort_attribute_name=None, sort_direction=None, name_contains=None)
 
 
 @pytest.mark.parametrize("offset", [1, 5, 10, 20])
@@ -75,7 +75,7 @@ async def test_base_list_action_offset(
 
     await base_list_action(offset=offset)
 
-    spy.assert_called_once_with(limit=None, offset=offset, sort_attribute_name=None, sort_direction=None)
+    spy.assert_called_once_with(limit=None, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None)
 
 
 @pytest.mark.anyio
@@ -87,7 +87,7 @@ async def test_base_list_action_sort_attribute_name(
 
     await base_list_action(sort_attribute_name="name")
 
-    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name="name", sort_direction=None)
+    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name="name", sort_direction=None, name_contains=None)
 
 
 @pytest.mark.parametrize("direction", [SortingDirection.ASC, SortingDirection.DESC])
@@ -101,7 +101,7 @@ async def test_base_list_action_sort_direction(
 
     await base_list_action(sort_direction=direction)
 
-    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name=None, sort_direction=direction)
+    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name=None, sort_direction=direction, name_contains=None)
 
 
 @pytest.mark.parametrize(
@@ -119,7 +119,7 @@ async def test_base_list_action_limit_offset(
 
     await base_list_action(limit=limit, offset=offset)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None)
+    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None)
 
 
 @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ async def test_base_list_action_limit_offset_sort_attribute_name(
 
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None)
+    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None, name_contains=None)
 
 
 @pytest.mark.parametrize(
@@ -163,7 +163,7 @@ async def test_base_list_action_limit_offset_sort_attribute_name_sort_direction(
 
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction)
+    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction, name_contains=None)
 
 
 @pytest.mark.parametrize("pk", [1, 2, 3, 4, 5])

--- a/tests/test_actions/test_base_actions.py
+++ b/tests/test_actions/test_base_actions.py
@@ -61,7 +61,9 @@ async def test_base_list_action_limit(
 
     await base_list_action(limit=limit)
 
-    spy.assert_called_once_with(limit=limit, offset=None, sort_attribute_name=None, sort_direction=None, name_contains=None)
+    spy.assert_called_once_with(
+        limit=limit, offset=None, sort_attribute_name=None, sort_direction=None, name_contains=None
+    )
 
 
 @pytest.mark.parametrize("offset", [1, 5, 10, 20])
@@ -75,7 +77,9 @@ async def test_base_list_action_offset(
 
     await base_list_action(offset=offset)
 
-    spy.assert_called_once_with(limit=None, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None)
+    spy.assert_called_once_with(
+        limit=None, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None
+    )
 
 
 @pytest.mark.anyio
@@ -87,7 +91,9 @@ async def test_base_list_action_sort_attribute_name(
 
     await base_list_action(sort_attribute_name="name")
 
-    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name="name", sort_direction=None, name_contains=None)
+    spy.assert_called_once_with(
+        limit=None, offset=None, sort_attribute_name="name", sort_direction=None, name_contains=None
+    )
 
 
 @pytest.mark.parametrize("direction", [SortingDirection.ASC, SortingDirection.DESC])
@@ -101,7 +107,9 @@ async def test_base_list_action_sort_direction(
 
     await base_list_action(sort_direction=direction)
 
-    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name=None, sort_direction=direction, name_contains=None)
+    spy.assert_called_once_with(
+        limit=None, offset=None, sort_attribute_name=None, sort_direction=direction, name_contains=None
+    )
 
 
 @pytest.mark.parametrize(
@@ -119,7 +127,9 @@ async def test_base_list_action_limit_offset(
 
     await base_list_action(limit=limit, offset=offset)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None)
+    spy.assert_called_once_with(
+        limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None
+    )
 
 
 @pytest.mark.parametrize(
@@ -138,7 +148,9 @@ async def test_base_list_action_limit_offset_sort_attribute_name(
 
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None, name_contains=None)
+    spy.assert_called_once_with(
+        limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None, name_contains=None
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,7 +175,9 @@ async def test_base_list_action_limit_offset_sort_attribute_name_sort_direction(
 
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction)
 
-    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction, name_contains=None)
+    spy.assert_called_once_with(
+        limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction, name_contains=None
+    )
 
 
 @pytest.mark.parametrize("pk", [1, 2, 3, 4, 5])

--- a/tests/test_actions/test_base_actions.py
+++ b/tests/test_actions/test_base_actions.py
@@ -61,9 +61,7 @@ async def test_base_list_action_limit(
 
     await base_list_action(limit=limit)
 
-    spy.assert_called_once_with(
-        limit=limit, offset=None, sort_attribute_name=None, sort_direction=None, name_contains=None
-    )
+    spy.assert_called_once_with(limit=limit, offset=None, sort_attribute_name=None, sort_direction=None, filters=None)
 
 
 @pytest.mark.parametrize("offset", [1, 5, 10, 20])
@@ -77,9 +75,7 @@ async def test_base_list_action_offset(
 
     await base_list_action(offset=offset)
 
-    spy.assert_called_once_with(
-        limit=None, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None
-    )
+    spy.assert_called_once_with(limit=None, offset=offset, sort_attribute_name=None, sort_direction=None, filters=None)
 
 
 @pytest.mark.anyio
@@ -91,9 +87,7 @@ async def test_base_list_action_sort_attribute_name(
 
     await base_list_action(sort_attribute_name="name")
 
-    spy.assert_called_once_with(
-        limit=None, offset=None, sort_attribute_name="name", sort_direction=None, name_contains=None
-    )
+    spy.assert_called_once_with(limit=None, offset=None, sort_attribute_name="name", sort_direction=None, filters=None)
 
 
 @pytest.mark.parametrize("direction", [SortingDirection.ASC, SortingDirection.DESC])
@@ -108,7 +102,7 @@ async def test_base_list_action_sort_direction(
     await base_list_action(sort_direction=direction)
 
     spy.assert_called_once_with(
-        limit=None, offset=None, sort_attribute_name=None, sort_direction=direction, name_contains=None
+        limit=None, offset=None, sort_attribute_name=None, sort_direction=direction, filters=None
     )
 
 
@@ -127,9 +121,7 @@ async def test_base_list_action_limit_offset(
 
     await base_list_action(limit=limit, offset=offset)
 
-    spy.assert_called_once_with(
-        limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None, name_contains=None
-    )
+    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=None, sort_direction=None, filters=None)
 
 
 @pytest.mark.parametrize(
@@ -148,9 +140,7 @@ async def test_base_list_action_limit_offset_sort_attribute_name(
 
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name)
 
-    spy.assert_called_once_with(
-        limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None, name_contains=None
-    )
+    spy.assert_called_once_with(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=None, filters=None)
 
 
 @pytest.mark.parametrize(
@@ -176,7 +166,7 @@ async def test_base_list_action_limit_offset_sort_attribute_name_sort_direction(
     await base_list_action(limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction)
 
     spy.assert_called_once_with(
-        limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction, name_contains=None
+        limit=limit, offset=offset, sort_attribute_name=name, sort_direction=direction, filters=None
     )
 
 


### PR DESCRIPTION
## Summary
- Adds `name_contains` parameter to `BaseRepository.list()` and `BaseListAction.__call__()`
- Needed by meldingen backend to support `q` search param on classification and asset-type list endpoints (see Amsterdam/meldingen#680)

## Test plan
- [ ] Verify mypy passes
- [ ] Verify existing tests still pass